### PR TITLE
Add Rob Paveza as editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
             companyURL: "https://www.microsoft.com/",
             url: "https://github.com/LuHuangMSFT",
           },
+          {
+            name: "Rob Paveza",
+            company: "Microsoft",
+            companyURL: "https://www.microsoft.com/",
+            url: "https://github.com/robpaveza",
+          },
         ],
         xref: {
           specs: [
@@ -2286,10 +2292,10 @@ dictionary InstallResultEventInit : EventInit {
     <section class="appendix informative" id="acknowledgements">
       <h2>Acknowledgements</h2>
       <p>
-        The editors thank Mike West, Diego González, Daniel Murphy, Rob Paveza,
-        Alex Russell, Arthur Sonzogni, and participants in WICG, WebApps WG,
-        TAG, browser standards-position discussions, and early developer trials
-        for feedback that informed this draft.
+        The editors thank Mike West, Diego González, Daniel Murphy, Alex
+        Russell, Arthur Sonzogni, and participants in WICG, WebApps WG, TAG,
+        browser standards-position discussions, and early developer trials for
+        feedback that informed this draft.
       </p>
     </section>
   </body>


### PR DESCRIPTION
## Summary

- add Rob Paveza to the ReSpec editor metadata
- remove Rob from the editors' acknowledgments list

## Testing

- `npx respec --localhost index.html /tmp/install-element-respec-output.html --haltonerror --haltonwarn --no-sandbox --verbose`